### PR TITLE
Add indexing parameter to meshgrid call

### DIFF
--- a/models/tensorBase.py
+++ b/models/tensorBase.py
@@ -307,7 +307,7 @@ class TensorBase(torch.nn.Module):
             torch.linspace(0, 1, gridSize[0]),
             torch.linspace(0, 1, gridSize[1]),
             torch.linspace(0, 1, gridSize[2]),
-        ), -1).to(self.device)
+        ), -1, indexing='ij').to(self.device)
         dense_xyz = self.aabb[0] * (1-samples) + self.aabb[1] * samples
 
         # dense_xyz = dense_xyz


### PR DESCRIPTION
Using a newer version or PyTorch (required for modern GPUs), the following user warning will be thrown during the training process:

```
 UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument.
(Triggered internally at ..\aten\src\ATen\native\TensorShape.cpp:3191.)
``` 

Avoid this by adding the `indexing` parameter to the `torch.meshgrid` call.

See the [PyTorch documentation on meshgrid](https://pytorch.org/docs/stable/generated/torch.meshgrid.html#torch-meshgrid) for more info.